### PR TITLE
Better formatting of README.md, close #2 by adding a requirements.txt, conform to pylint standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,54 @@
 # scantastic-tool
-It's bloody scantastic
-======================
+
+## It's bloody scantastic
 
 If you like this and are feeling a bit(coin) generous - 1JdSGqg2zGTbpFMJPLbWoXg7Nng3z1Qp58
 
-It works for me.
-http://makthepla.net/scantastichax.png - Old Example
+It works for me: http://makthepla.net/scantastichax.png - Old Example
 
-Dependencies: (DIY - I ain't supportin shit)
-Masscan - https://github.com/robertdavidgraham/masscan
-ElasticSearch - http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_installing_elasticsearch.html
-Kibana - http://www.elasticsearch.org/overview/kibana/installation/
+ - Dependencies: (DIY - I ain't supportin shit)
+ - Masscan - https://github.com/robertdavidgraham/masscan
+ - ElasticSearch - http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_installing_elasticsearch.html
+ - Kibana - http://www.elasticsearch.org/overview/kibana/installation/
 
-Python libs -
-pip install elasticsearch
-pip install requests
-pip install netaddr
-pip install xmltodict
-pip install numpy
+Python libs:
+
+ - pip install elasticsearch
+ - pip install requests
+ - pip install netaddr
+ - pip install xmltodict
+ - pip install numpy
 
 This tool can be used to store masscan data in elasticsearch, 
 (the scantastic plugin in the image is not here)
 It allows the output of a directory busting tool to be inserted also. 
+
 All your base are belong to us. I might maintain or improve this over time. MIGHT.
 
-quickstart: - example usage
+## Quickstart
+
+### Example usage
 
 Run and import a scan of home /24 network
+
+```
 ./scantastic.py -s -H 192.168.192.0/24 -p 80,443 -x homescan.xml
+```
 
 Export homescan to a list of urls
+
+```
 ./scantastic.py -eurl -x homescan.xml > urlist
+```
 
 Brute force the url list using wordlist and put results into index homescan
 using 10 threads (By default it uses 1 thread)
+
+```
 ./scantastic.py -d -u urlist -w some_wordlist -i homescan -t 10
+```
 
-
-
+```
 root@ubuntu:~/scantastic-tool# ./scantastic.py -h
 usage: scantastic.py [-h] [-v] [-d] [-s] [-noes] [-sl] [-in] [-e] [-eurl]
                      [-del] [-H HOST] [-p PORTS] [-x XML] [-w WORDS] [-u URLS]
@@ -75,3 +86,4 @@ optional arguments:
                         Specify the ElasticSearch index
   -a AGENT, --agent AGENT
                         Specify a User Agent for requests
+```

--- a/masscan.py
+++ b/masscan.py
@@ -1,57 +1,60 @@
-#A class to run masscan and import the results to ES
-import subprocess, socket
+#!/usr/bin/env python
+# A class to run masscan and import the results to ES
+
+import subprocess
+import socket
 import xmltodict
 from elasticsearch import Elasticsearch
 from datetime import datetime
 
+
 class Masscan:
-	#Initialize with range, output, ports
-	
-	def __init__(self, ip_r, xml_o, ps):
-		self.ip_range = ip_r
-		self.xml_output = xml_o
-		self.ports = ps
+    # Initialize with range, output, ports
 
-	def run(self):
-		self.args = ("/root/masscan/bin/masscan", "-sS", "-Pn", self.ip_range, 
-						"-oX", self.xml_output, "--rate=15000", "-p", 
-						self.ports, "--open")
-		popen = subprocess.Popen(self.args, stdout=subprocess.PIPE)
-		popen.wait()
-		self.output = popen.stdout.read()
-		print "Scan completed!"
+    def __init__(self, ip_r, xml_o, ps):
+        self.ip_range = ip_r
+        self.xml_output = xml_o
+        self.ports = ps
 
-	def runfile(self):
-		self.args = ("/root/masscan/bin/masscan", "-sS", "-Pn", "-iL", self.ip_range,
-						"-oX", self.xml_output, "--rate=15000", "-p", self.ports,
-						 "--open")
-		popen = subprocess.Popen(self.args, stdout=subprocess.PIPE)
-		popen.wait()
-		self.output = popen.stdout.read()
-		print "Scan completed!"
+    def run(self):
+        self.args = ("masscan", "-sS", "-Pn", self.ip_range,
+                     "-oX", self.xml_output, "--rate=15000", "-p",
+                     self.ports, "--open")
+        popen = subprocess.Popen(self.args, stdout=subprocess.PIPE)
+        popen.wait()
+        self.output = popen.stdout.read()
+        print "Scan completed!"
 
-	def import_es(self, es_index, host, port):
-		es = Elasticsearch([{u'host': host, u'port': port}])
-		try:
-			with open(self.xml_output, "r") as xmlfile:
-				data=xmlfile.read().replace('\n','')
-			xml = xmltodict.parse(data)
-			nmaprun = xml['nmaprun']
-			host = nmaprun['host']
-		except:
-			print "IO Error"
-		for entry in host:
-			port = entry['ports']['port']
-			try:
-				name,alias,addrlist = socket.gethostbyaddr(entry['address']['@addr'])
-			except socket.herror:
-				name = entry['address']['@addr']
-			dataentry = {
-				'timestamp': datetime.now(),
-				'ip': entry['address']['@addr'],
-				'port': port['@portid'],
-				'name': name,
-				'link': 'http://'+name+'/'
-			}	
-			result = es.index(index=es_index, doc_type='hax', body=dataentry)
-			
+    def runfile(self):
+        self.args = ("masscan", "-sS", "-Pn", "-iL", self.ip_range,
+                     "-oX", self.xml_output, "--rate=15000", "-p", self.ports,
+                     "--open")
+        popen = subprocess.Popen(self.args, stdout=subprocess.PIPE)
+        popen.wait()
+        self.output = popen.stdout.read()
+        print "Scan completed!"
+
+    def import_es(self, es_index, host, port):
+        es = Elasticsearch([{u'host': host, u'port': port}])
+        try:
+            with open(self.xml_output, "r") as xmlfile:
+                data = xmlfile.read().replace('\n', '')
+            xml = xmltodict.parse(data)
+            nmaprun = xml['nmaprun']
+            host = nmaprun['host']
+        except:
+            print "IO Error"
+        for entry in host:
+            port = entry['ports']['port']
+            try:
+                name, alias, addrlist = socket.gethostbyaddr(entry['address']['@addr'])
+            except socket.herror:
+                name = entry['address']['@addr']
+            dataentry = {
+                'timestamp': datetime.now(),
+                'ip': entry['address']['@addr'],
+                'port': port['@portid'],
+                'name': name,
+                'link': 'http://' + name + '/'
+            }
+            result = es.index(index=es_index, doc_type='hax', body=dataentry)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+elasticsearch==1.3.0
+requests==2.5.1
+netaddr==0.7.13
+xmltodict==0.9.2
+numpy==1.9.1

--- a/scantastic.py
+++ b/scantastic.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 import multiprocessing
 import argparse
 import sys
@@ -9,233 +10,247 @@ from time import sleep
 from elasticsearch import Elasticsearch
 from masscan import Masscan
 from xmltourl import Xml2urls
-from pprint import pprint
 from numpy import array_split
+
 requests.packages.urllib3.disable_warnings()
 
-def version_info():
-	VERSION_INFO = 'Scantastic v1.0'
-	AUTHOR_INFO = 'Author: Ciaran McNally - http://makthepla.net'
-	print'  _ _ _..__|_ _. __|_o _'
-	print' _>(_(_|| ||_(_|_> |_|(_'
-	print'========================='
-	print VERSION_INFO
-	print AUTHOR_INFO
 
-#Split the list of urls into chunks for threading
+def version_info():
+    VERSION_INFO = 'Scantastic v1.0'
+    AUTHOR_INFO = 'Author: Ciaran McNally - http://makthepla.net'
+    print'  _ _ _..__|_ _. __|_o _'
+    print' _>(_(_|| ||_(_|_> |_|(_'
+    print'========================='
+    print VERSION_INFO
+    print AUTHOR_INFO
+
+
+# Split the list of urls into chunks for threading
 def split_urls(u, t):
-	print 'Number of URLS: '+str(len(u))
-	print 'Threads: '+str(t)
-	print 'URLS in each split: '+str(len(u)/t)
-	print '========================='
-	sleep(1)
-	return array_split(u,t)
+    print 'Number of URLS: ' + str(len(u))
+    print 'Threads: ' + str(t)
+    print 'URLS in each split: ' + str(len(u) / t)
+    print '========================='
+    sleep(1)
+    return array_split(u, t)
+
 
 def returnIPaddr(u):
-	ip = ""
-	if u.startswith('http://'):
-		remainhttp = u[7:]
-		ip = string.split(remainhttp,'/')[0]
-	if u.startswith('https://'):
-		remainhttps = u[8:]
-		ip = string.split(remainhttps,'/')[0]
-	return ip
+    ip = ""
+    if u.startswith('http://'):
+        remainhttp = u[7:]
+        ip = string.split(remainhttp, '/')[0]
+    if u.startswith('https://'):
+        remainhttps = u[8:]
+        ip = string.split(remainhttps, '/')[0]
+    return ip
+
 
 def returnTitle(content):
-	t1=''
-	t2=''
-	if '<title>' in content:
-		t1 = string.split(content, '<title>')[1]
-		t2 = string.split(t1, '</title>')[0]
-	return t2
+    t1 = ''
+    t2 = ''
+    if '<title>' in content:
+        t1 = string.split(content, '<title>')[1]
+        t2 = string.split(t1, '</title>')[0]
+    return t2
 
-#Make requests
+
+# Make requests
 def requestor(urls, dirb, host, port, agent, esindex, usees):
-	data = {}
-	es = Elasticsearch([{u'host': host, u'port': port}])
-	user_agent = {'User-agent': agent}
-	for url in urls:
-		urld = url+dirb
-		try:
-			r = requests.get(urld, timeout=10, headers=user_agent, verify=False)
-			stat = r.status_code
-			time = datetime.utcnow()
-			cont_len = len(r.content)
-			title = returnTitle(r.content)
-			if len(r.content) >= 500:
-				content = r.content[0:500]
-			else:
-				content = r.content
-			ip = returnIPaddr(url)
-			if 'image' in r.headers['content-type']:
-				content = 'image'
-			if(r.status_code == 200):
-				print urld+' - '+ str(r.status_code) +':'+ str(len(r.content))
-		except requests.exceptions.Timeout:
-			#print urld+' - Timeout'
-			stat = -1
-		except requests.exceptions.ConnectionError:
-			#print url+dirb+' - Connection Error!'
-			stat = -2
-		except requests.exceptions.TooManyRedirects:
-			#print urld+' - Too many redirects!'
-			stat = -3
-		except:
-			stat = 0
-		
-		if stat > 0:
-			data = {
-				'timestamp': time,
-				'ip': ip,
-				'status': stat,
-				'content-length': cont_len,
-				'content': content,
-				'title': title,
-				'link': url+dirb,
-				'directory': dirb
-			}
-			try:
-				if data['status'] == 200:
-					if( usees == False):
-						result = es.index(index=esindex, doc_type='hax', 
-							body=data)
-					else:
-						pass
-				else:
-					pass
-			except:
-				data['title'] = 'Unicode Error'
-				data['content'] = 'Unicode Error'
-				if data['status'] == 200:
-					if( usees == False):
-						result = es.index(index=esindex, doc_type='hax', 
-							body=data)
-					else:
-						pass
-				else:
-					pass
+    data = {}
+    es = Elasticsearch([{u'host': host, u'port': port}])
+    user_agent = {'User-agent': agent}
+    for url in urls:
+        urld = url + dirb
+        try:
+            r = requests.get(urld, timeout=10, headers=user_agent, verify=False)
+            stat = r.status_code
+            time = datetime.utcnow()
+            cont_len = len(r.content)
+            title = returnTitle(r.content)
+            if len(r.content) >= 500:
+                content = r.content[0:500]
+            else:
+                content = r.content
+            ip = returnIPaddr(url)
+            if 'image' in r.headers['content-type']:
+                content = 'image'
+            if r.status_code == 200:
+                print urld + ' - ' + str(r.status_code) + ':' + str(len(r.content))
+        except requests.exceptions.Timeout:
+            # print urld+' - Timeout'
+            stat = -1
+        except requests.exceptions.ConnectionError:
+            # print url+dirb+' - Connection Error!'
+            stat = -2
+        except requests.exceptions.TooManyRedirects:
+            # print urld+' - Too many redirects!'
+            stat = -3
+        except:
+            stat = 0
 
-#Run regular masscan on specified range
+        if stat > 0:
+            data = {
+                'timestamp': time,
+                'ip': ip,
+                'status': stat,
+                'content-length': cont_len,
+                'content': content,
+                'title': title,
+                'link': url + dirb,
+                'directory': dirb
+            }
+            try:
+                if data['status'] == 200:
+                    if usees == False:
+                        result = es.index(index=esindex, doc_type='hax',
+                                          body=data)
+                    else:
+                        pass
+                else:
+                    pass
+            except:
+                data['title'] = 'Unicode Error'
+                data['content'] = 'Unicode Error'
+                if data['status'] == 200:
+                    if usees == False:
+                        result = es.index(index=esindex, doc_type='hax',
+                                          body=data)
+                    else:
+                        pass
+                else:
+                    pass
+
+
+# Run regular masscan on specified range
 def scan(host, ports, xml, index, eshost, esport, noin):
-	ms = Masscan(host, 'xml/'+xml, ports)
-	ms.run()
-	if(noin == False):
-		ms.import_es(index, eshost, esport)
-		print ms.output
+    ms = Masscan(host, 'xml/' + xml, ports)
+    ms.run()
+    if noin == False:
+        ms.import_es(index, eshost, esport)
+        print ms.output
 
-#Run masscan on file of ranges
+
+# Run masscan on file of ranges
 def scanlst(hostfile, ports, xml, index, eshost, esport, noin):
-	ms = Masscan(hostfile, 'xml/'+xml, ports)
-	ms.runfile()
-	if(noin == False):
-		ms.import_es(index, eshost, esport)
-		print ms.output
+    ms = Masscan(hostfile, 'xml/' + xml, ports)
+    ms.runfile()
+    if noin == False:
+        ms.import_es(index, eshost, esport)
+        print ms.output
+
 
 def export_xml(xml, index, eshost, esport):
-	ms = Masscan('x','xml/'+xml,'y')
-	ms.import_es(index, eshost, esport)
+    ms = Masscan('x', 'xml/' + xml, 'y')
+    ms.import_es(index, eshost, esport)
+
 
 def delete_index(dindex, eshost, esport):
-	url = 'http://'+eshost+':'+str(esport)+'/'+dindex
-	print 'deleting index: '+url
-	r = requests.delete(url)
-	print r.content
+    url = 'http://' + eshost + ':' + str(esport) + '/' + dindex
+    print 'deleting index: ' + url
+    r = requests.delete(url)
+    print r.content
+
 
 def export_urls(xml):
-	x = Xml2urls(xml)
-	x.run()
+    x = Xml2urls(xml)
+    x.run()
+
 
 if __name__ == '__main__':
-	parse = argparse.ArgumentParser()
-	parse.add_argument('-v','--version', action='store_true',default=False,
-		help='Version information')
-	parse.add_argument('-d','--dirb',action='store_true',default=False,
-		help='Run directory brute force. Requires --urls & --words')
-	parse.add_argument('-s', '--scan',action='store_true',default=False,
-		help='Run masscan on single range. Specify --host & --ports & --xml')
-	parse.add_argument('-noes','--noelastics',action='store_true',default=False,
-		help='Run scan without elasticsearch insertion')
-	parse.add_argument('-sl', '--scanlist',action='store_true', default='scanlist',
-		help='Run masscan on a list ranges. Requires --host & --ports & --xml')
-	parse.add_argument('-in','--noinsert', action='store_true', default=False,
-		help='Perform a scan without inserting to elasticsearch')
-	parse.add_argument('-e', '--export', action='store_true', default=False,
-		help='Export a scan XML into elasticsearch. Requires --xml')
-	parse.add_argument('-eurl', '--exporturl', action='store_true', default=False,
-		help='Export urls to scan from XML file. Requires --xml')
-	parse.add_argument('-del','--delete',action='store_true', default=False,
-		help='Specify an index to delete.')
-	parse.add_argument('-H','--host',type=str, help='Scan this host or list of hosts')
-	parse.add_argument('-p', '--ports', type=str, 
-		default='21,22,80,443,8000,8080,8443,2080,2443,9090,6000,8888,50080,50443,5900',
-		help='Specify ports in masscan format. (ie.0-1000 or 80,443...)')
-	parse.add_argument('-x','--xml', type=str,default='scan.xml',
-		help='Specify an XML file to store output in')
-	parse.add_argument('-w','--words',type=str,default='words',
-		help='Wordlist to be used with --dirb')
-	parse.add_argument('-u','--urls',type=str,default='urls',
-		help='List of Urls to be used with --dirb')
-	parse.add_argument('-t','--threads',type=int,default=1,
-		help='Specify the number of threads to use.')
-	parse.add_argument('-esh','--eshost',type=str,default=u'127.0.0.1',
-		help='Specify the elasticsearch host')
-	parse.add_argument('-esp','--port',type=int,default=5900,
-		help='Specify ElasticSearch port')
-	parse.add_argument('-i','--index',type=str,default='scantastic',
-		help='Specify the ElasticSearch index')
-	parse.add_argument('-a','--agent',type=str,default='Scantastic O_o',
-		help='Specify a User Agent for requests')
-	args = parse.parse_args()
+    parse = argparse.ArgumentParser()
+    parse.add_argument('-v', '--version', action='store_true', default=False,
+                       help='Version information')
+    parse.add_argument('-d', '--dirb', action='store_true', default=False,
+                       help='Run directory brute force. Requires --urls & --words')
+    parse.add_argument('-s', '--scan', action='store_true', default=False,
+                       help='Run masscan on single range. Specify --host & --ports & --xml')
+    parse.add_argument('-noes', '--noelastics', action='store_true', default=False,
+                       help='Run scan without elasticsearch insertion')
+    parse.add_argument('-sl', '--scanlist', action='store_true', default='scanlist',
+                       help='Run masscan on a list ranges. Requires --host & --ports & --xml')
+    parse.add_argument('-in', '--noinsert', action='store_true', default=False,
+                       help='Perform a scan without inserting to elasticsearch')
+    parse.add_argument('-e', '--export', action='store_true', default=False,
+                       help='Export a scan XML into elasticsearch. Requires --xml')
+    parse.add_argument('-eurl', '--exporturl', action='store_true', default=False,
+                       help='Export urls to scan from XML file. Requires --xml')
+    parse.add_argument('-del', '--delete', action='store_true', default=False,
+                       help='Specify an index to delete.')
+    parse.add_argument('-H', '--host', type=str, help='Scan this host or list of hosts')
+    parse.add_argument('-p', '--ports', type=str,
+                       default='21,22,80,443,8000,8080,8443,2080,2443,9090,6000,8888,50080,50443,5900',
+                       help='Specify ports in masscan format. (ie.0-1000 or 80,443...)')
+    parse.add_argument('-x', '--xml', type=str, default='scan.xml',
+                       help='Specify an XML file to store output in')
+    parse.add_argument('-w', '--words', type=str, default='words',
+                       help='Wordlist to be used with --dirb')
+    parse.add_argument('-u', '--urls', type=str, default='urls',
+                       help='List of Urls to be used with --dirb')
+    parse.add_argument('-t', '--threads', type=int, default=1,
+                       help='Specify the number of threads to use.')
+    parse.add_argument('-esh', '--eshost', type=str, default=u'127.0.0.1',
+                       help='Specify the elasticsearch host')
+    parse.add_argument('-esp', '--port', type=int, default=5900,
+                       help='Specify ElasticSearch port')
+    parse.add_argument('-i', '--index', type=str, default='scantastic',
+                       help='Specify the ElasticSearch index')
+    parse.add_argument('-a', '--agent', type=str, default='Scantastic O_o',
+                       help='Specify a User Agent for requests')
+    args = parse.parse_args()
 
-	if len(sys.argv) <= 1:
-		parse.print_help()
-		sys.exit(0)
-	
-	if (args.version):
-		version_info()
-		
-	if (args.scan) and (args.host != None):
-		scan(args.host, args.ports, args.xml, args.index, args.eshost, 
-				args.port, args.noinsert)
-	
-	if (args.scanlist) and (args.host != None):
-		scanlst(args.host, args.ports, args.xml, args.index, args.eshost, 
-				args.port, args.noinsert)	
-	
-	if (args.export):
-		export_xml(args.xml, args.index, args.eshost, args.port)	
-	
-	if (args.delete):
-		delete_index(args.index, args.eshost, args.port)
-	
-	if (args.exporturl):
-		export_urls(args.xml)
-		
-	if (args.dirb):
-		try:
-			with open(args.urls) as f:
-				urls = f.read().splitlines()
-			with open(args.words) as f:
-				words = f.read().splitlines()
-		except IOError:
-			print 'File not found!'
-		threads = []
-		splitlist = list(split_urls(urls, args.threads))
+    if len(sys.argv) <= 1:
+        parse.print_help()
+        sys.exit(0)
 
-		for word in words:
-			print 'Word: '+word
-			for i in range(0, len(splitlist)):
-				p = multiprocessing.Process(target=requestor, 
-					args=(list(splitlist[i]), word, args.eshost, args.port, args.agent, args.index, args.noelastics))
-				threads.append(p)
-			try:
-				for p in threads:
-					p.start()
-				for p in threads:
-					p.join()
-			except KeyboardInterrupt:
-				print 'Killing Threads...'
-				for p in threads:
-					p.terminate()
-				sys.exit(0)
-			threads = []
+    if args.version:
+        version_info()
+
+    if args.scan and (args.host is not None):
+        scan(args.host, args.ports, args.xml, args.index, args.eshost,
+             args.port, args.noinsert)
+
+    if args.scanlist and (args.host is not None):
+        scanlst(args.host, args.ports, args.xml, args.index, args.eshost,
+                args.port, args.noinsert)
+
+    if args.export:
+        export_xml(args.xml, args.index, args.eshost, args.port)
+
+    if args.delete:
+        delete_index(args.index, args.eshost, args.port)
+
+    if args.exporturl:
+        export_urls(args.xml)
+
+    if args.dirb:
+        try:
+            with open(args.urls) as f:
+                urls = f.read().splitlines()
+            with open(args.words) as f:
+                words = f.read().splitlines()
+        except IOError:
+            print 'File not found!'
+        threads = []
+        splitlist = list(split_urls(urls, args.threads))
+
+        for word in words:
+            print 'Word: ' + word
+            for i in range(0, len(splitlist)):
+                p = multiprocessing.Process(target=requestor,
+                                            args=(
+                                                list(splitlist[i]), word, args.eshost, args.port, args.agent,
+                                                args.index,
+                                                args.noelastics))
+                threads.append(p)
+            try:
+                for p in threads:
+                    p.start()
+                for p in threads:
+                    p.join()
+            except KeyboardInterrupt:
+                print 'Killing Threads...'
+                for p in threads:
+                    p.terminate()
+                sys.exit(0)
+            threads = []

--- a/xmltourl.py
+++ b/xmltourl.py
@@ -1,36 +1,38 @@
-#!/usr/bin/python
-#Generate URLS from scanfile
-#===============================
+#!/usr/bin/env python
+# Generate URLS from scanfile
+# ===============================
+
 import xmltodict
 
+
 class Xml2urls:
-	def __init__(self, xmlfile):
-		self.xmlf = xmlfile
-		self.data = ''
-		try:
-			with open('xml/'+self.xmlf) as myf:
-				self.data = myf.read().replace('\n', '')
-		except IOError:
-			print 'File IO Error'
-		self.xml = xmltodict.parse(self.data)
-			
+    def __init__(self, xmlfile):
+        self.xmlf = xmlfile
+        self.data = ''
+        try:
+            with open('xml/' + self.xmlf) as myf:
+                self.data = myf.read().replace('\n', '')
+        except IOError:
+            print 'File IO Error'
+        self.xml = xmltodict.parse(self.data)
 
-	def run(self):
-		nmaprun = self.xml['nmaprun']
-		host = nmaprun['host']
 
-		for entry in host:
-			port = entry['ports']['port']
-			if int(port['@portid']) == 80:
-				name = entry['address']['@addr']
-				print 'http://'+name+'/'
-			elif int(port['@portid']) == 443:
-				name = entry['address']['@addr']
-				print 'https://'+name+'/'
-			elif int(port['@portid']) == 21:
-				name = entry['address']['@addr']
-				print 'ftp://'+name+'/'
-			else:
-				name = entry['address']['@addr']
-				print 'http://'+name+':'+str(port['@portid'])+'/'
+    def run(self):
+        nmaprun = self.xml['nmaprun']
+        host = nmaprun['host']
+
+        for entry in host:
+            port = entry['ports']['port']
+            if int(port['@portid']) == 80:
+                name = entry['address']['@addr']
+                print 'http://' + name + '/'
+            elif int(port['@portid']) == 443:
+                name = entry['address']['@addr']
+                print 'https://' + name + '/'
+            elif int(port['@portid']) == 21:
+                name = entry['address']['@addr']
+                print 'ftp://' + name + '/'
+            else:
+                name = entry['address']['@addr']
+                print 'http://' + name + ':' + str(port['@portid']) + '/'
 


### PR DESCRIPTION
Convert README.txt to README.md and to give better formatting.

Introduce a requirements.txt for quickly installing pip packages, as mentioned in #2 

Conform to pylint standards, format code accordingly, remove unused imports.

Remove absolute undocumented path to masscan, it should be assumed user has it in their $PATH rather than some absolute location.

Use `#!/usr/bin/env python` over `#!/usr/bin/python` so virtualenvs work.